### PR TITLE
Investigate mobile no sound issue

### DIFF
--- a/styles/accessibility.js
+++ b/styles/accessibility.js
@@ -90,7 +90,9 @@ class AccessibilityManager {
         } catch (e) {}
       };
       if ("addEventListener" in speechSynthesis) {
-        speechSynthesis.addEventListener("voiceschanged", onVoices, { once: true });
+        speechSynthesis.addEventListener("voiceschanged", onVoices, {
+          once: true,
+        });
       } else {
         speechSynthesis.onvoiceschanged = onVoices;
       }
@@ -98,14 +100,19 @@ class AccessibilityManager {
       const u = new SpeechSynthesisUtterance(" ");
       u.volume = 0;
       u.rate = 1;
+      u.onstart = () => {
+        this.ttsUnlocked = true;
+      };
       u.onend = () => {
         this.ttsUnlocked = true;
       };
-      try { speechSynthesis.resume(); } catch (e) {}
+      u.onerror = () => {
+        this.ttsUnlocked = true;
+      };
+      try {
+        speechSynthesis.resume();
+      } catch (e) {}
       speechSynthesis.speak(u);
-      setTimeout(() => {
-        try { speechSynthesis.cancel(); } catch (e) {}
-      }, 50);
     } catch (e) {}
   }
 
@@ -124,7 +131,9 @@ class AccessibilityManager {
       const done = () => {
         if (resolved) return;
         resolved = true;
-        try { this.voicesReady = speechSynthesis.getVoices().length > 0; } catch (e) {}
+        try {
+          this.voicesReady = speechSynthesis.getVoices().length > 0;
+        } catch (e) {}
         resolve();
       };
 
@@ -154,7 +163,9 @@ class AccessibilityManager {
     if (!("speechSynthesis" in window)) return;
     this.unlockTTS();
     await this.waitForVoices(1500);
-    try { speechSynthesis.resume(); } catch (e) {}
+    try {
+      speechSynthesis.resume();
+    } catch (e) {}
   }
 
   toggleMenu() {
@@ -540,6 +551,9 @@ class AccessibilityManager {
   }
 
   async speakText(text) {
+    try {
+      await this.ensureTtsReady();
+    } catch (e) {}
     return new Promise((resolve, reject) => {
       try {
         if (speechSynthesis.speaking || speechSynthesis.pending) {

--- a/styles/accessibility.js
+++ b/styles/accessibility.js
@@ -130,7 +130,6 @@ class AccessibilityManager {
 
       const handler = () => {
         if (resolved) return;
-        resolved = true;
         try {
           if (speechSynthesis.getVoices().length > 0) {
             if ("removeEventListener" in speechSynthesis) {


### PR DESCRIPTION
Fix Text-to-Speech (TTS) audio not playing on mobile devices.

Mobile browsers (especially iOS Safari/Android Chrome) block `speechSynthesis` audio until a user interaction occurs. Additionally, the list of available voices can be delayed, and the TTS engine sometimes requires a `resume()` call. This PR introduces an "unlock" mechanism on the first user gesture, ensures voices are loaded before speaking, and explicitly resumes the engine to ensure audio output.

---
<a href="https://cursor.com/background-agent?bcId=bc-1ab2179d-9f97-47fa-a6ef-26a5f1b0e17f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1ab2179d-9f97-47fa-a6ef-26a5f1b0e17f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

